### PR TITLE
repaired mmu; changed debug led functions

### DIFF
--- a/mmu.v
+++ b/mmu.v
@@ -1,39 +1,39 @@
 //memory managemant unit
 module mmu
 (
-	input rst,
-	input clk,
-	input [23:0] address,
-	input read,
-	output reg [31:0] dataOut, 	//upto 32 bits
-	input write,
-	input [31:0] dataIn,		//upto 32 bits
-	input [1:0] byteCount,		//count of bytes - 1 to read/write
-	output reg dataOutReady,	//expects to data be read in one cycle, if read is not cleared load again
-	output reg dataInReady
+    input rst,
+    input clk,
+    input [23:0] address,
+    input read,
+    output reg [31:0] dataOut, 	//upto 32 bits
+    input write,
+    input [31:0] dataIn,		//upto 32 bits
+    input [1:0] byteCount,		//count of bytes - 1 to read/write
+    output reg dataOutReady,	//expects to data be read in one cycle, if read is not cleared load again
+    output reg dataInReady
 );
 
 reg [7:0] sram[255:0];
 reg [7:0] rom[255:0];
 
 initial begin
-	//$readmemh("rom.mem", rom, 0);
-	rom[0] = 8'd255; //8'h05;
-	rom[1] = 8'd254; //8'hBA;
-	rom[2] = 8'd255; //8'hAD;
-	rom[3] = 8'd254; //8'h05;
-	rom[4] = 8'd255; //8'hF0;
-	rom[5] = 8'd254; //8'h0D;
-	rom[6] = 8'd16;
-	rom[7] = 8'd16;
-	rom[8] = 8'd16;
-	rom[9] = 8'h00;
-	rom[10] = 8'h00;
-	rom[11] = 8'h00;
-	rom[12] = 8'h00;
-	rom[13] = 8'h00;
-	rom[14] = 8'h00;
-	rom[15] = 8'h00;
+    //$readmemh("rom.mem", rom, 0);
+    rom[0] = 8'd255; //8'h05;
+    rom[1] = 8'd254; //8'hBA;
+    rom[2] = 8'd255; //8'hAD;
+    rom[3] = 8'd254; //8'h05;
+    rom[4] = 8'd255; //8'hF0;
+    rom[5] = 8'd254; //8'h0D;
+    rom[6] = 8'd16;
+    rom[7] = 8'd16;
+    rom[8] = 8'd16;
+    rom[9] = 8'h00;
+    rom[10] = 8'h00;
+    rom[11] = 8'h00;
+    rom[12] = 8'h00;
+    rom[13] = 8'h00;
+    rom[14] = 8'h00;
+    rom[15] = 8'h00;
 end
 
 reg [1:0] byteNumber;
@@ -41,65 +41,65 @@ reg readActive;
 reg writeActive;
 
 always @(posedge read) begin
-//	byteNumber <= 0;
-//	readActive <= 1;
-//	dataOut <= 0;
+//    byteNumber <= 0;
+//    readActive <= 1;
+//    dataOut <= 0;
 end
 
 always @(posedge write) begin
-//	byteNumber <= 0;
-//	writeActive <= 1;
+//    byteNumber <= 0;
+//    writeActive <= 1;
 end
 
 always @(posedge clk) begin
-	if(rst) begin
-		dataOut <= 0;
-		dataInReady <= 0;
-		dataOutReady <= 0;
-		readActive <= 0;
-	end else begin
-		if(dataOutReady || dataInReady) begin
-			dataInReady <= 1'b0;
-			dataOutReady <= 1'b0;
-		end else begin
-			if(read) begin
-			 	if(readActive) begin
-					if(!address[8]) begin
-						dataOut <= (dataOut << (byteNumber * 8)) | (sram[address[7:0] + byteNumber]);
-					end else begin
-						dataOut <= (dataOut << (byteNumber * 8)) | (rom[address[7:0] + byteNumber]);
-					end
-					if(byteNumber != byteCount) begin
-						byteNumber <= byteNumber + 1;
-					end else begin
-						byteNumber <= 0;
-						dataOutReady <= 1'b1;
-						readActive <= 1'b0;
-					end
-				end else begin
+    if(rst) begin
+    	dataOut <= 0;
+    	dataInReady <= 0;
+    	dataOutReady <= 0;
+    	readActive <= 0;
+    end else begin
+    	if(dataOutReady || dataInReady) begin
+    		dataInReady <= 1'b0;
+    		dataOutReady <= 1'b0;
+    	end else begin
+    		if(read) begin
+    		 	if(readActive) begin
+    				if(!address[8]) begin
+    					dataOut <= (dataOut << (byteNumber * 8)) | (sram[address[7:0] + byteNumber]);
+    				end else begin
+    					dataOut <= (dataOut << (byteNumber * 8)) | (rom[address[7:0] + byteNumber]);
+    				end
+    				if(byteNumber != byteCount) begin
+    					byteNumber <= byteNumber + 1;
+    				end else begin
+    					byteNumber <= 0;
+    					dataOutReady <= 1'b1;
+    					readActive <= 1'b0;
+    				end
+    			end else begin
                     readActive <= 1'b1;
                     dataOut <= 0;
-				end
-			end else if (write) begin
-			 	if(writeActive) begin
-					if(!address[8]) begin	
-						sram[address[7:0] + byteNumber]	<= (dataIn >> (byteNumber * 8));
-					end else begin
-						//rom read only
-					end
-					if(byteNumber != byteCount) begin
-						byteNumber <= byteNumber + 1;
-					end else begin
-						byteNumber <= 0;
-						dataInReady <= 1'b1;
-						writeActive <= 1'b0;
-					end
-				end else begin
+    			end
+    		end else if (write) begin
+    		 	if(writeActive) begin
+    				if(!address[8]) begin	
+    					sram[address[7:0] + byteNumber]	<= (dataIn >> (byteNumber * 8));
+    				end else begin
+    					//rom read only
+    				end
+    				if(byteNumber != byteCount) begin
+    					byteNumber <= byteNumber + 1;
+    				end else begin
+    					byteNumber <= 0;
+    					dataInReady <= 1'b1;
+    					writeActive <= 1'b0;
+    				end
+    			end else begin
                     writeActive <= 1'b1;
-				end
-			end 
-		end
-	end
+    			end
+    		end 
+    	end
+    end
 end
 
 endmodule

--- a/mmu.v
+++ b/mmu.v
@@ -18,15 +18,15 @@ reg [7:0] rom[255:0];
 
 initial begin
 	//$readmemh("rom.mem", rom, 0);
-	rom[0] = 8'hff; //8'h05;
-	rom[1] = 8'hff; //8'hBA;
-	rom[2] = 8'hff; //8'hAD;
-	rom[3] = 8'hff; //8'h05;
-	rom[4] = 8'hff; //8'hF0;
-	rom[5] = 8'hff; //8'h0D;
-	rom[6] = 8'h10;
-	rom[7] = 8'h00;
-	rom[8] = 8'h00;
+	rom[0] = 8'd255; //8'h05;
+	rom[1] = 8'd254; //8'hBA;
+	rom[2] = 8'd255; //8'hAD;
+	rom[3] = 8'd254; //8'h05;
+	rom[4] = 8'd255; //8'hF0;
+	rom[5] = 8'd254; //8'h0D;
+	rom[6] = 8'd16;
+	rom[7] = 8'd16;
+	rom[8] = 8'd16;
 	rom[9] = 8'h00;
 	rom[10] = 8'h00;
 	rom[11] = 8'h00;
@@ -41,14 +41,14 @@ reg readActive;
 reg writeActive;
 
 always @(posedge read) begin
-	byteNumber <= 0;
-	readActive <= 1;
-	dataOut <= 0;
+//	byteNumber <= 0;
+//	readActive <= 1;
+//	dataOut <= 0;
 end
 
 always @(posedge write) begin
-	byteNumber <= 0;
-	writeActive <= 1;
+//	byteNumber <= 0;
+//	writeActive <= 1;
 end
 
 always @(posedge clk) begin
@@ -65,34 +65,37 @@ always @(posedge clk) begin
 			if(read) begin
 			 	if(readActive) begin
 					if(!address[8]) begin
-						dataOut <= dataOut | (sram[address[7:0] + byteNumber] << byteNumber * 8);
+						dataOut <= (dataOut << (byteNumber * 8)) | (sram[address[7:0] + byteNumber]);
 					end else begin
-						dataOut <= dataOut | (rom[address[7:0] + byteNumber] << byteNumber * 8);
+						dataOut <= (dataOut << (byteNumber * 8)) | (rom[address[7:0] + byteNumber]);
 					end
 					if(byteNumber != byteCount) begin
 						byteNumber <= byteNumber + 1;
 					end else begin
-						byteNumber <= 0; //optional
+						byteNumber <= 0;
 						dataOutReady <= 1'b1;
 						readActive <= 1'b0;
 					end
 				end else begin
+                    readActive <= 1'b1;
+                    dataOut <= 0;
 				end
 			end else if (write) begin
 			 	if(writeActive) begin
 					if(!address[8]) begin	
-						sram[address[7:0] + byteNumber]	<= (dataIn >> byteNumber * 8);
+						sram[address[7:0] + byteNumber]	<= (dataIn >> (byteNumber * 8));
 					end else begin
 						//rom read only
 					end
 					if(byteNumber != byteCount) begin
 						byteNumber <= byteNumber + 1;
 					end else begin
-						byteNumber <= 0; //optional
+						byteNumber <= 0;
 						dataInReady <= 1'b1;
 						writeActive <= 1'b0;
 					end
 				end else begin
+                    writeActive <= 1'b1;
 				end
 			end 
 		end

--- a/top.v
+++ b/top.v
@@ -1,10 +1,10 @@
 module top
 (
-	input nrst,
+    input nrst,
     input clk,
-	inout [7:0] io,
-	input [7:0] in,
-	output [7:0] out,
+    inout [7:0] io,
+    input [7:0] in,
+    output [7:0] out,
     output [5:0] led
 );
 
@@ -40,24 +40,24 @@ reg [31:0] clockCounter = 0;
 wire clk2 = clockCounter[22];
 
 mmu memEmu (.rst(nrst), .clk(clk2),
-	.address(address),
-	.read(read),
-	.dataOut(dataIn),
-	.write(write),
-	.dataIn(dataOut),
-	.byteCount(byteCount),
-	.dataOutReady(dataInReady),
-	.dataInReady(dataOutReady));
+    .address(address),
+    .read(read),
+    .dataOut(dataIn),
+    .write(write),
+    .dataIn(dataOut),
+    .byteCount(byteCount),
+    .dataOutReady(dataInReady),
+    .dataInReady(dataOutReady));
 
 cpu cpu0 (.rst(nrst), .clk(clk2),
-	.address(address),
-	.read(read),
-	.dataIn(dataIn),
-	.write(write),
-	.dataOut(dataOut),
-	.byteCount(byteCount),
-	.dataInReady(dataInReady),
-	.dataOutReady(dataOutReady));
+    .address(address),
+    .read(read),
+    .dataIn(dataIn),
+    .write(write),
+    .dataOut(dataOut),
+    .byteCount(byteCount),
+    .dataInReady(dataInReady),
+    .dataOutReady(dataOutReady));
 
 reg [7:0] busByte = 0;
 reg [7:0] cachedInByte = 0;
@@ -70,11 +70,11 @@ assign led = ledFlop;
 
 always @(posedge clk) begin
     clockCounter <= clockCounter + 1;
-	//if(write && address[15:8] == 0) begin
-		ledFlop[4:0] <= ~dataIn[4:0];
-		ledFlop[5:5] <= ~clk2;
-		//ledFlop <= ~address[5:0];//dataIn[5:0];
-	//end
+    //if(write && address[15:8] == 0) begin
+    	ledFlop[4:0] <= ~dataIn[4:0];
+    	ledFlop[5:5] <= ~clk2;
+    	//ledFlop <= ~address[5:0];//dataIn[5:0];
+    //end
 end
 
 endmodule

--- a/top.v
+++ b/top.v
@@ -37,9 +37,9 @@ wire [1:0] byteCount;
 
 reg [31:0] clockCounter = 0;
 
-wire clk2 = clockCounter[20];
+wire clk2 = clockCounter[22];
 
-mmu memEmu (.rst(!nrst), .clk(clk2),
+mmu memEmu (.rst(nrst), .clk(clk2),
 	.address(address),
 	.read(read),
 	.dataOut(dataIn),
@@ -49,7 +49,7 @@ mmu memEmu (.rst(!nrst), .clk(clk2),
 	.dataOutReady(dataInReady),
 	.dataInReady(dataOutReady));
 
-cpu cpu0 (.rst(!nrst), .clk(clk2),
+cpu cpu0 (.rst(nrst), .clk(clk2),
 	.address(address),
 	.read(read),
 	.dataIn(dataIn),
@@ -61,7 +61,7 @@ cpu cpu0 (.rst(!nrst), .clk(clk2),
 
 reg [7:0] busByte = 0;
 reg [7:0] cachedInByte = 0;
-assign io = ioIsInput ? 8'dZ : busByte;
+//assign io = ioIsInput ? 8'dZ : busByte;
 
 //assign led = clockCounter[24:20];//~ledcounter;
 
@@ -71,7 +71,9 @@ assign led = ledFlop;
 always @(posedge clk) begin
     clockCounter <= clockCounter + 1;
 	//if(write && address[15:8] == 0) begin
-		ledFlop <= ~address[5:0];//dataOut[5:0];
+		ledFlop[4:0] <= ~dataIn[4:0];
+		ledFlop[5:5] <= ~clk2;
+		//ledFlop <= ~address[5:0];//dataIn[5:0];
 	//end
 end
 


### PR DESCRIPTION
mmu problems were dataOut calculations ("()" missing in important places) and forgetting to reset dataOut before shifting new data into it that isnt big enough to override previous data in dataOut.
for better debug, led functions where changed to:
last led is clk2
all other leds show first 5 bit of dataIn (which is dataOut of MMU)

also edited rom code for easy detection by humans to determine if rom is read correctly 

EDIT: nrst is currently NOT inverted because tang nano 20k has non inverted button input
Didn't test to read multiple bytes, only tested with nop, dbg and jmp which all only load one byte while op code fetch